### PR TITLE
[BUGFIX] Insert target language correctly

### DIFF
--- a/Build/UnitTests.xml
+++ b/Build/UnitTests.xml
@@ -1,0 +1,47 @@
+<!--
+    Boilerplate for a unit test suite setup.
+
+    This file is loosely maintained within TYPO3 testing-framework, extensions
+    are encouraged to not use it directly, but to copy it to an own place,
+    for instance Build/UnitTests.xml.
+    Note UnitTestsBootstrap.php should be copied along the way.
+
+    Functional tests should extend \TYPO3\TestingFramework\Core\Tests\FunctionalTestCase,
+    take a look at this class for further documentation on how to run the suite.
+
+    TYPO3 CMS functional test suite also needs phpunit bootstrap code, the
+    file is located next to this .xml as FunctionalTestsBootstrap.php
+
+    @todo: Make phpunit v9 compatible, add the xml things to phpunit tag, see core versions.
+-->
+<phpunit
+    backupGlobals="true"
+    bootstrap="UnitTestsBootstrap.php"
+    cacheResult="false"
+    colors="true"
+    convertDeprecationsToExceptions="true"
+    convertErrorsToExceptions="true"
+    convertWarningsToExceptions="true"
+    convertNoticesToExceptions="true"
+    forceCoversAnnotation="false"
+    processIsolation="false"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    verbose="false"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+    failOnWarning="true"
+    failOnRisky="true"
+>
+	<testsuites>
+		<testsuite name="Localizer tests">
+			<directory>../Functional/</directory>
+		</testsuite>
+	</testsuites>
+    <php>
+        <const name="TYPO3_MODE" value="BE" />
+        <ini name="display_errors" value="1" />
+        <env name="TYPO3_CONTEXT" value="Testing" />
+    </php>
+</phpunit>

--- a/Build/UnitTestsBootstrap.php
+++ b/Build/UnitTestsBootstrap.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Boilerplate for a unit test phpunit boostrap file.
+ *
+ * This file is loosely maintained within TYPO3 testing-framework, extensions
+ * are encouraged to not use it directly, but to copy it to an own place,
+ * usually in parallel to a UnitTests.xml file.
+ *
+ * This file is defined in UnitTests.xml and called by phpunit
+ * before instantiating the test suites.
+ *
+ * The recommended way to execute the suite is "runTests.sh". See the
+ * according script within TYPO3 core's Build/Scripts directory and
+ * adapt to extensions needs.
+ */
+(static function () {
+    $testbase = new \TYPO3\TestingFramework\Core\Testbase();
+
+    // These if's are for core testing (package typo3/cms) only. cms-composer-installer does
+    // not create the autoload-include.php file that sets these env vars and sets composer
+    // mode to true. testing-framework can not be used without composer anyway, so it is safe
+    // to do this here. This way it does not matter if 'bin/phpunit' or 'vendor/phpunit/phpunit/phpunit'
+    // is called to run the tests since the 'relative to entry script' path calculation within
+    // SystemEnvironmentBuilder is not used. However, the binary must be called from the document
+    // root since getWebRoot() uses 'getcwd()'.
+    if (!getenv('TYPO3_PATH_ROOT')) {
+        putenv('TYPO3_PATH_ROOT=' . rtrim($testbase->getWebRoot(), '/'));
+    }
+    if (!getenv('TYPO3_PATH_WEB')) {
+        putenv('TYPO3_PATH_WEB=' . rtrim($testbase->getWebRoot(), '/'));
+    }
+
+    $testbase->defineSitePath();
+
+    $requestType = \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_BE | \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI;
+    \TYPO3\TestingFramework\Core\SystemEnvironmentBuilder::run(0, $requestType);
+
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3conf/ext');
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/assets');
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/var/tests');
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/var/transient');
+
+    // Retrieve an instance of class loader and inject to core bootstrap
+    $classLoader = require $testbase->getPackagesPath() . '/autoload.php';
+    \TYPO3\CMS\Core\Core\Bootstrap::initializeClassLoader($classLoader);
+
+    // Initialize default TYPO3_CONF_VARS
+    $configurationManager = new \TYPO3\CMS\Core\Configuration\ConfigurationManager();
+    $GLOBALS['TYPO3_CONF_VARS'] = $configurationManager->getDefaultConfiguration();
+
+    $cache = new \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend(
+        'core',
+        new \TYPO3\CMS\Core\Cache\Backend\NullBackend('production', [])
+    );
+
+    // Set all packages to active
+    if (interface_exists(\TYPO3\CMS\Core\Package\Cache\PackageCacheInterface::class)) {
+        $packageManager = \TYPO3\CMS\Core\Core\Bootstrap::createPackageManager(\TYPO3\CMS\Core\Package\UnitTestPackageManager::class, \TYPO3\CMS\Core\Core\Bootstrap::createPackageCache($cache));
+    } else {
+        // v10 compatibility layer
+        // @deprecated Will be removed when v10 compat is dropped from testing-framework
+        $packageManager = \TYPO3\CMS\Core\Core\Bootstrap::createPackageManager(\TYPO3\CMS\Core\Package\UnitTestPackageManager::class, $cache);
+    }
+
+    \TYPO3\CMS\Core\Utility\GeneralUtility::setSingletonInstance(\TYPO3\CMS\Core\Package\PackageManager::class, $packageManager);
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::setPackageManager($packageManager);
+
+    $testbase->dumpClassLoadingInformation();
+
+    \TYPO3\CMS\Core\Utility\GeneralUtility::purgeInstances();
+})();

--- a/Classes/Runner/DownloadFile.php
+++ b/Classes/Runner/DownloadFile.php
@@ -139,17 +139,11 @@ class DownloadFile
      */
     protected function adjustContent(string &$content, string $iso2): void
     {
-        $search = '<t3_targetLang translate="no">';
-        $position = strpos($content, $search);
-
-        // Fallback to without translate="no" parameter.
-        if ($position === false) {
-            $search = '<t3_targetLang>';
-            $position = strpos($content, $search);
-        }
-
-        $start = $position + strlen($search);
-        $content = substr_replace($content, $iso2, $start, 0);
+        $content = preg_replace(
+            '#(<t3_targetLang(?: translate="no")?>)[^<]*(</t3_targetLang>)#',
+            '$1' . $iso2 . '$2',
+            $content,
+        );
     }
 
     /**

--- a/Tests/Unit/Runner/DownloadFileTest.php
+++ b/Tests/Unit/Runner/DownloadFileTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localizationteam\Localizer\Tests\Functional\Repository;
+
+use Localizationteam\Localizer\Runner\DownloadFile;
+use ReflectionClass;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class DownloadFileTest extends UnitTestCase
+{
+    public static function adjustContentDataProvider(): array
+    {
+        return [
+            'empty t3_targetLang' => ['<t3_targetLang translate="no"></t3_targetLang>', 'de', '<t3_targetLang translate="no">de</t3_targetLang>'],
+            'pre-filled t3_targetLang' => ['<t3_targetLang translate="no">de_DE</t3_targetLang>', 'de', '<t3_targetLang translate="no">de</t3_targetLang>'],
+            'without translate no' => ['<t3_targetLang></t3_targetLang>', 'de', '<t3_targetLang>de</t3_targetLang>'],
+            'pre-filled t3_targetLang without translate no' => ['<t3_targetLang>de_DE</t3_targetLang>', 'de', '<t3_targetLang>de</t3_targetLang>'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider adjustContentDataProvider
+     */
+    public function adjustContent(string $content, string $iso2, string $expectedContent): void
+    {
+        $class = new ReflectionClass(DownloadFile::class);
+        $adjustContent = $class->getMethod('adjustContent');
+
+        $adjustContent->invokeArgs(new DownloadFile(), [&$content, $iso2]);
+        self::assertSame($expectedContent, $content);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
 		"ci:php:php-cs-fixer:dry": [
 			"php-cs-fixer fix --allow-risky=yes --dry-run -vvv --diff"
 		],
+		"ci:tests:unit": ".Build/bin/phpunit -c Build/UnitTests.xml Tests/Unit/ -v",
 		"ci:tests:functional": "XDEBUG_MODE=coverage typo3DatabaseDriver=pdo_sqlite .Build/bin/phpunit --log-junit functional-test-report.xml --coverage-cobertura=functional-tests-coverage.xml -c Build/FunctionalTests.xml Tests/Functional/ -v",
 		"ci:tests": [
 			"@ci:tests:functional"


### PR DESCRIPTION
With the previous implementation, the desired target language code
would be inserted before any existing value in the t3_targetLang
element, which leads to an invalid language code.

Before: <t3_targetLang translate="no">dede_DE</t3_targetLang>
After: <t3_targetLang translate="no">de</t3_targetLang>